### PR TITLE
refactor: The Client post method now returns the correct upstream status

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -57,13 +57,11 @@ impl HttpClient for ApiClient {
             .header(reqwest::header::AUTHORIZATION, &self.bearer_token)
             .json(&body)
             .send()
-            .await?
-            .text()
             .await?;
 
         let response = Response {
-            status: 200,
-            content: res,
+            status: res.status().into(),
+            content: res.text().await?,
         };
         Ok(response)
     }


### PR DESCRIPTION
E.g if Twitter fails with a 403, it will also return a 403