### PR TITLE
Feat!: Change the CLI structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ sudo chmod +x /usr/local/bin/twitter
 ### CLI Mode
 ```bash
 # Tweet
-twitter --tweet "Building something cool today"
+twitter tweet --body "Building something cool today"
 ```
 
 ### Server Mode
 ```bash
 # Start local server (default port 3000)
-twitter --serve
+twitter serve
 
 # Custom port
-twitter --serve --port 8080
+twitter serve --port 8080
 
 # Post via HTTP
 curl -X POST http://localhost:3000/api/tweet \


### PR DESCRIPTION
### Description
The current CLI does things like `twitter —tweet` this is fine for now but it will be bloated in case of new features. For example to add media we’d do something like `tweet —body “Hello —media file.png` this looks fine until you zoom out and realise that we have another mode called server mode that also has access to body that does not mean anything to them.

In this PR, modes are the first param just like git does.
```shell
## Create a new tweet.
twitter tweet —body “This is better”

## Start the server
twitter serve —port 3434
``` 