### PR TITLE
Support for piped input in tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ sudo chmod +x /usr/local/bin/twitter
 ```bash
 # Tweet
 twitter tweet --body "Building something cool today"
+
+# Or with piped input
+echo "I love CLIs" | twitter tweet
+
+# Or from text files
+cat drafts.txt | twitter tweet
 ```
 
 ### Server Mode

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,9 +44,11 @@ pub async fn run() {
                 Some(tweet) => tweet,
                 None => {
                     let mut buf = String::new();
-                    io::stdin().read_to_string(&mut buf).unwrap(); // I don't expect this to fail.
+                    io::stdin()
+                        .read_to_string(&mut buf)
+                        .expect("Failed to read tweet!");
 
-                    buf
+                    buf.trim().to_string()
                 }
             };
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,7 +44,7 @@ pub async fn run() {
                 Some(tweet) => tweet,
                 None => {
                     let mut buf = String::new();
-                    io::stdin().read_to_string(&mut buf).unwrap();
+                    io::stdin().read_to_string(&mut buf).unwrap(); // I don't expect this to fail.
 
                     buf
                 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,5 @@
+use std::io::{self, Read};
+
 use clap::{Parser, Subcommand};
 
 use crate::{
@@ -26,7 +28,7 @@ enum Commands {
     Tweet {
         /// The body of the tweet
         #[arg(long, short, name = "body")]
-        body: String,
+        body: Option<String>,
     },
 }
 
@@ -37,7 +39,18 @@ pub async fn run() {
         Commands::Serve { port } => server::run(port).await,
         Commands::Tweet { body } => {
             let client = ApiClient::new();
-            let payload = CreateTweet { text: body };
+
+            let tweet_body = match body {
+                Some(tweet) => tweet,
+                None => {
+                    let mut buf = String::new();
+                    io::stdin().read_to_string(&mut buf).unwrap();
+
+                    buf
+                }
+            };
+
+            let payload = CreateTweet { text: tweet_body };
             let api_res = tweet::create(client, payload).await;
 
             match api_res {


### PR DESCRIPTION
This pull request enhances the CLI's tweet functionality by allowing users to provide tweet content via piped input or text files, in addition to the existing command-line argument. The changes improve usability for scripting and automation scenarios.

**CLI usability improvements:**

* The `body` argument for the `tweet` command in `src/cli/mod.rs` is now optional, enabling tweet content to be read from standard input if not provided directly.
* Logic added to `run()` in `src/cli/mod.rs` to read tweet content from stdin when the `body` argument is absent, supporting piped and file input. [[1]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR1-R2) [[2]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffL40-R53)

**Documentation updates:**

* The `README.md` now includes usage examples for tweeting with piped input and text files, clarifying the new functionality.