### PR TITLE
Update README with ArchLinux installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ I love creating content on Twitter but twitter.com leads to doomscrolling. This 
 Simple CLI for posting to Twitter using their API v2. No authentication flow - just configure once and tweet.
 
 ## Installation
-Download the appropriate binary from [releases](https://github.com/StanleyMasinde/twitter/releases/latest):
+### ArchLinux
+ArchLinux users can install from the community maintained AUR binary [package](https://aur.archlinux.org/packages/twitter-cli) with yay:
+```bash
+yay -S twitter-cli
+```
+
+You can also download the appropriate binary for your machine from [releases](https://github.com/StanleyMasinde/twitter/releases/latest):
 
 ### Linux (Static x64)
 ```bash


### PR DESCRIPTION
Added ArchLinux installation instructions to README.

**Description**
PR addresses changes made to README to reflect #11 for the arch user installation issue. 



**Additional context**
Used `twitter-cli` name as `twitter` was already taken in the AUR