### PR TITLE
29 update fails on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ On Windows, run:
 ```powershell
 twitter update
 ```
-`twitter update` replaces the current `twitter.exe` location. Run an elevated terminal only if the executable is in a protected directory (for example `C:\Program Files`).
+`twitter update` schedules replacement of the current `twitter.exe` after the running process exits. Run an elevated terminal only if the executable is in a protected directory (for example `C:\Program Files`).
 
 ### ArchLinux
 ArchLinux users can install the community maintained AUR binary [package](https://aur.archlinux.org/packages/twitter-cli) using yay or any other AUR helper:


### PR DESCRIPTION
**Description**
This PR is an attempt to fix the self update issue that was seen in Darwin. It however found that it was not a bug but a feature so I updated the docs.

**Related issue(s)**
This PR closes #29. It was not a bug but a misunderstood feature.

**Changes introduced**
List key changes in this PR:
- Improve docs for self update
- Improve Windows install experience 

**How to test**

```sh
sudo twitter cargo run — update
```

**Checklist**
- [x] Code compiles and runs
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `cargo fmt` has been run
- [x] `cargo clippy` shows no new warnings

**Additional context**
NA