### PR TITLE
fix(ci): install sqlite3 via vcpkg for Windows release builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,13 @@ jobs:
             os: windows-latest
             name: windows-x86_64
             archive_ext: zip
+            vcpkg_triplet: x64-windows-static-md
 
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
             name: windows-arm
             archive_ext: zip
+            vcpkg_triplet: arm64-windows-static-md
 
     runs-on: ${{ matrix.os }}
 
@@ -72,6 +74,27 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install SQLite via vcpkg (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) {
+            $vcpkgRoot = "C:\vcpkg"
+          }
+          $vcpkgExe = Join-Path $vcpkgRoot "vcpkg.exe"
+          if (-not (Test-Path $vcpkgExe)) {
+            throw "vcpkg.exe not found at $vcpkgExe"
+          }
+
+          & $vcpkgExe install "sqlite3:${{ matrix.vcpkg_triplet }}"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install sqlite3 with vcpkg."
+          }
+
+          "VCPKG_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
+          "VCPKGRS_TRIPLET=${{ matrix.vcpkg_triplet }}" >> $env:GITHUB_ENV
 
       - name: Build release
         shell: bash


### PR DESCRIPTION
  rusqlite introduced libsqlite3-sys lookup on Windows, causing release job failures after the schedule feature landed.
  This updates the release workflow to provision SQLite explicitly on Windows runners without switching to bundled SQLite.

  ### What changed

  - Added vcpkg_triplet per Windows target in the matrix:
      - x86_64-pc-windows-msvc -> x64-windows-static-md
      - aarch64-pc-windows-msvc -> arm64-windows-static-md
  - Added a Windows-only step before cargo build to: - locate vcpkg.exe - install sqlite3 for the target triplet - export VCPKG_ROOT and VCPKGRS_TRIPLET via GITHUB_ENV

  ### Why

  - Previous versions built on Windows because SQLite was not required.
  - Schedule feature added rusqlite, which requires sqlite3 at build/link time.
  - CI now provides sqlite3 through vcpkg, keeping dependency management in workflow instead of enabling rusqlite bundled mode.

  ### Runtime implications

  - Uses static-md triplets, so sqlite3 should be linked statically into the Windows binary.
  - No standalone sqlite3.dll is expected for release artifacts.

  ### Validation

  - Workflow YAML updated in .github/workflows/main.yml.
  - Next Windows CI run should confirm build/link success for both Windows targets.

