### PR TITLE
feat: add endpoint to get the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,24 @@ The CLI prints how many records were removed, for example:
 Cleared 3 scheduled tweets.
 ```
 
+### Timeline
+Fetch your reverse-chronological home timeline.
+```bash
+twitter timeline
+```
+
+### Current user
+Fetch details for the currently authenticated user (`GET /2/users/me`).
+```bash
+twitter me
+```
+Example output:
+```text
+User Id: 123456789
+Name: Jane Doe
+Username: @janedoe
+```
+
 **API Response:**
 ```text
 Tweet Id: 2006409743426818416

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -78,6 +78,9 @@ enum Commands {
 
     /// Timeline
     Timeline {},
+
+    /// Show information about the current authenticated user
+    Me {},
 }
 
 #[derive(Debug, Subcommand)]
@@ -343,6 +346,13 @@ pub fn run() {
                         );
                     }
                 }
+                Err(err) => eprintln!("{}", err.message),
+            }
+        }
+        Commands::Me {} => {
+            let me_res = twitter::user::me();
+            match me_res {
+                Ok(ok) => println!("{}", ok.content),
                 Err(err) => eprintln!("{}", err.message),
             }
         }

--- a/src/twitter/mod.rs
+++ b/src/twitter/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub mod media;
 pub(crate) mod timeline;
 pub mod tweet;
+pub mod user;
 
 pub struct Response<T> {
     #[allow(dead_code)]

--- a/src/twitter/user.rs
+++ b/src/twitter/user.rs
@@ -1,0 +1,60 @@
+use std::fmt::Display;
+
+use serde::Deserialize;
+
+use crate::{twitter::Response, utils::oauth_get_header};
+
+#[derive(Debug, Deserialize)]
+pub struct CurrentUserData {
+    pub id: String,
+    pub name: String,
+    pub username: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CurrentUserResponse {
+    pub data: CurrentUserData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CurrentUserError {
+    pub message: String,
+}
+
+impl Display for CurrentUserResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "User Id: {}\nName: {}\nUsername: @{}",
+            self.data.id, self.data.name, self.data.username
+        )
+    }
+}
+
+pub fn me() -> Result<Response<CurrentUserResponse>, CurrentUserError> {
+    let url = "https://api.x.com/2/users/me";
+    let auth_header = oauth_get_header(url, &());
+
+    let response = curl_rest::Client::default()
+        .get()
+        .header(curl_rest::Header::Authorization(auth_header.into()))
+        .send(url)
+        .map_err(|err| CurrentUserError {
+            message: err.to_string(),
+        })?;
+
+    if (200..300).contains(&response.status.as_u16()) {
+        let user_data: CurrentUserResponse =
+            serde_json::from_slice(&response.body).map_err(|err| CurrentUserError {
+                message: err.to_string(),
+            })?;
+        Ok(Response {
+            status: response.status.as_u16(),
+            content: user_data,
+        })
+    } else {
+        Err(CurrentUserError {
+            message: String::from_utf8_lossy(&response.body).to_string(),
+        })
+    }
+}


### PR DESCRIPTION
## Description
  This PR adds timeline and current-user commands, and introduces account-scoped caching of user_id to avoid repeated /2/users/me calls. It also centralizes
  OAuth header construction to remove duplicated auth logic across API modules.

  ## Related issue(s)
  N/A

  ## Changes introduced

  - Implemented timeline API support in src/twitter/timeline.rs with typed responses/errors and required query handling (max_results) in both request and OAuth
    signing.
  - Added twitter timeline command flow in src/cli/mod.rs, including timeline output rendering via existing TweetCreateResponse Display.
  - Added sqlite-backed user_id cache in src/utils/mod.rs, keyed by config current_account index, with /2/users/me fetch on cache miss.
  - Added centralized OAuth helpers in src/utils/mod.rs and refactored tweet/media/timeline/user paths to use them.
  - Added twitter me command backed by new src/twitter/user.rs (GET /2/users/me) with typed output.
  - Updated README usage docs with timeline and me commands plus sample me output.

  ## How to test
```sh
twitter me
```

  ## Checklist

  - [x] Code compiles and runs
  - [ ] Tests added or updated
  - [x] Documentation updated (if applicable)
  - [ ] cargo fmt has been run
  - [ ] cargo clippy shows no new warnings

  ## Additional context

  - user_id cache is persisted in sqlite (twitter-cli/db.sqlite3) table account_user_cache.
  - Cache key is current_account index from config, so multi-account setups are isolated.
  - timeline currently uses max_results=10; making it user-configurable can be a follow-up.
