### PR TITLE
feat: add the mentions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,14 @@ Fetch your reverse-chronological home timeline.
 twitter timeline
 ```
 
+### Mentions
+Fetch tweets that mention the currently authenticated user.
+```bash
+twitter mentions
+```
+
 ### Current user
-Fetch details for the currently authenticated user (`GET /2/users/me`).
+Fetch details for the currently authenticated user. 
 ```bash
 twitter me
 ```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -79,6 +79,9 @@ enum Commands {
     /// Timeline
     Timeline {},
 
+    /// Mentions
+    Mentions {},
+
     /// Show information about the current authenticated user
     Me {},
 }
@@ -340,10 +343,33 @@ pub fn run() {
                     }
 
                     for tweet in tweets {
-                        println!(
-                            "{}\n",
-                            twitter::TweetCreateResponse { data: tweet }
-                        );
+                        println!("{}\n", twitter::TweetCreateResponse { data: tweet });
+                    }
+                }
+                Err(err) => eprintln!("{}", err.message),
+            }
+        }
+        Commands::Mentions {} => {
+            let user_id = match utils::get_current_user_id() {
+                Ok(id) => id,
+                Err(err) => {
+                    eprintln!("{err}");
+                    return;
+                }
+            };
+
+            let mentions = twitter::mentions::Mentions::new(user_id).max_results(10);
+            let mentions_res = mentions.fetch();
+            match mentions_res {
+                Ok(ok) => {
+                    let tweets = ok.content.data;
+                    if tweets.is_empty() {
+                        println!("No mentions found.");
+                        return;
+                    }
+
+                    for tweet in tweets {
+                        println!("{}\n", twitter::TweetCreateResponse { data: tweet });
                     }
                 }
                 Err(err) => eprintln!("{}", err.message),

--- a/src/twitter/mentions.rs
+++ b/src/twitter/mentions.rs
@@ -1,0 +1,85 @@
+use std::fmt::Display;
+
+use crate::{
+    twitter::{Response, TweetData},
+    utils::oauth_get_header,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct MentionsMeta {
+    #[allow(dead_code)]
+    pub result_count: u32,
+    #[allow(dead_code)]
+    pub next_token: Option<String>,
+    #[allow(dead_code)]
+    pub previous_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MentionsResponse {
+    pub data: Vec<TweetData>,
+    #[allow(dead_code)]
+    pub meta: Option<MentionsMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MentionsError {
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct Mentions {
+    user_id: String,
+    max_results: u8,
+}
+
+impl Mentions {
+    pub fn new(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+            max_results: 10,
+        }
+    }
+
+    pub fn max_results(mut self, max_results: u8) -> Self {
+        self.max_results = max_results.clamp(5, 100);
+        self
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/users/{}/mentions", self.user_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<MentionsResponse>, MentionsError> {
+        let url = self.url();
+        let max_results = self.max_results;
+        let auth_params =
+            oauth::ParameterList::new([("max_results", &max_results as &dyn Display)]);
+        let auth_header = oauth_get_header(url.as_str(), &auth_params);
+        let max_results_query = max_results.to_string();
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("max_results", max_results_query.as_str())
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| MentionsError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let mentions_data: MentionsResponse =
+                serde_json::from_slice(&response.body).map_err(|err| MentionsError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: mentions_data,
+            })
+        } else {
+            let err_data = String::from_utf8_lossy(&response.body).to_string();
+            Err(MentionsError { message: err_data })
+        }
+    }
+}

--- a/src/twitter/mod.rs
+++ b/src/twitter/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 pub mod media;
+pub(crate) mod mentions;
 pub(crate) mod timeline;
 pub mod tweet;
 pub mod user;


### PR DESCRIPTION
• Description
  Adds support for fetching mentions from the X API via GET /2/users/{id}/mentions, exposed as a new
  twitter mentions CLI command. This keeps the mentions flow consistent with the existing timeline
  command and makes it possible to check replies/mentions without opening x.com.

  Related issue(s)
  None.

  Changes introduced

  - Added a new mentions API client module for GET /2/users/{id}/mentions
  - Added a twitter mentions subcommand that resolves the current user ID and prints mention tweets
  - Updated the README usage docs to include the new mentions command

  How to test
  Provide valid X API credentials in your config, then run:

  cargo fmt --check
  cargo test
  twitter mentions

  Checklist

  - [x] Code compiles and runs
  - [ ] Tests added or updated
  - [x] Documentation updated (if applicable)
  - [x] cargo fmt has been run
  - [x] cargo clippy shows no new warnings

  Additional context
  The implementation intentionally mirrors the existing timeline command and reuses the same tweet
  display format to stay aligned with the current code style. No new tests were added because this change
  follows an existing endpoint pattern and the repo does not currently have endpoint-level integration
  tests.
