### PR TITLE
feat: add command for a user's liked tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ Fetch tweets that mention the currently authenticated user.
 twitter mentions
 ```
 
+### Likes
+Fetch tweets liked by the currently authenticated user.
+```bash
+twitter likes tweets
+```
+
 ### Current user
 Fetch details for the currently authenticated user. 
 ```bash

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -76,6 +76,12 @@ enum Commands {
         command: ScheduleEnum,
     },
 
+    /// Likes
+    Likes {
+        #[command(subcommand)]
+        command: LikesEnum,
+    },
+
     /// Timeline
     Timeline {},
 
@@ -106,6 +112,12 @@ enum ScheduleEnum {
 
     /// Run all ready-to-send scheduled tweets
     Run {},
+}
+
+#[derive(Debug, Subcommand)]
+enum LikesEnum {
+    /// Fetch tweets liked by the current authenticated user
+    Tweets {},
 }
 
 #[derive(Debug, clap::Args)]
@@ -320,6 +332,34 @@ pub fn run() {
                     );
                 } else {
                     println!("Total: {}", tweets.len());
+                }
+            }
+        },
+        Commands::Likes { command } => match command {
+            LikesEnum::Tweets {} => {
+                let user_id = match utils::get_current_user_id() {
+                    Ok(id) => id,
+                    Err(err) => {
+                        eprintln!("{err}");
+                        return;
+                    }
+                };
+
+                let likes = twitter::likes::Likes::new(user_id).max_results(10);
+                let likes_res = likes.fetch();
+                match likes_res {
+                    Ok(ok) => {
+                        let tweets = ok.content.data;
+                        if tweets.is_empty() {
+                            println!("No liked tweets found.");
+                            return;
+                        }
+
+                        for tweet in tweets {
+                            println!("{}\n", twitter::TweetCreateResponse { data: tweet });
+                        }
+                    }
+                    Err(err) => eprintln!("{}", err.message),
                 }
             }
         },

--- a/src/twitter/likes.rs
+++ b/src/twitter/likes.rs
@@ -1,0 +1,85 @@
+use std::fmt::Display;
+
+use crate::{
+    twitter::{Response, TweetData},
+    utils::oauth_get_header,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct LikesMeta {
+    #[allow(dead_code)]
+    pub result_count: u32,
+    #[allow(dead_code)]
+    pub next_token: Option<String>,
+    #[allow(dead_code)]
+    pub previous_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LikesResponse {
+    pub data: Vec<TweetData>,
+    #[allow(dead_code)]
+    pub meta: Option<LikesMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LikesError {
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct Likes {
+    user_id: String,
+    max_results: u8,
+}
+
+impl Likes {
+    pub fn new(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+            max_results: 10,
+        }
+    }
+
+    pub fn max_results(mut self, max_results: u8) -> Self {
+        self.max_results = max_results.clamp(5, 100);
+        self
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/users/{}/liked_tweets", self.user_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<LikesResponse>, LikesError> {
+        let url = self.url();
+        let max_results = self.max_results;
+        let auth_params =
+            oauth::ParameterList::new([("max_results", &max_results as &dyn Display)]);
+        let auth_header = oauth_get_header(url.as_str(), &auth_params);
+        let max_results_query = max_results.to_string();
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("max_results", max_results_query.as_str())
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| LikesError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let likes_data: LikesResponse =
+                serde_json::from_slice(&response.body).map_err(|err| LikesError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: likes_data,
+            })
+        } else {
+            let err_data = String::from_utf8_lossy(&response.body).to_string();
+            Err(LikesError { message: err_data })
+        }
+    }
+}

--- a/src/twitter/mod.rs
+++ b/src/twitter/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+pub(crate) mod likes;
 pub mod media;
 pub(crate) mod mentions;
 pub(crate) mod timeline;


### PR DESCRIPTION
**Description**
  Adds support for reading user interactions from the X API by introducing mentions and liked-posts
  commands. This PR adds `twitter mentions` for `GET /2/users/{id}/mentions` and `twitter likes tweets`
  for `GET /2/users/{id}/liked_tweets`, following the existing timeline command patterns so users can
  inspect mentions and liked tweets from the CLI.

  **Related issue(s)**
  None.

  **Changes introduced**
  - Added a `mentions` API client module and `twitter mentions` subcommand
  - Added a `likes` API client module and nested `twitter likes tweets` subcommand
  - Updated the README usage docs to cover both new commands

  **How to test**
  Provide valid X API credentials in your config, then run:
  ```sh
  cargo fmt --check
  cargo test
  twitter mentions
  twitter likes tweets
```

 **Checklist**

  - [x] Code compiles and runs
  - [ ] Tests added or updated
  - [x] Documentation updated (if applicable)
  - [x] cargo fmt has been run
  - [ ] cargo clippy shows no new warnings

  **Additional context**
  Both features intentionally mirror the existing read-only endpoint structure already used for timeline:
  resolve the authenticated user ID, fetch tweet data with OAuth-signed requests, and print results with
  the existing tweet formatter. No new tests were added because these changes follow established endpoint
  patterns and the project does not currently have endpoint-level integration coverage.