### PR TITLE
feat: add tweet lookup and richer timeline metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,12 @@ Fetch your reverse-chronological home timeline.
 twitter timeline
 ```
 
+### Tweet lookup
+Fetch a specific tweet by id.
+```bash
+twitter tweets --by-id 2006409743426818416
+```
+
 ### Mentions
 Fetch tweets that mention the currently authenticated user.
 ```bash

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -45,6 +45,13 @@ enum Commands {
         editor: bool,
     },
 
+    /// Fetch tweets
+    Tweets {
+        /// Fetch a tweet by id
+        #[arg(long, name = "by_id")]
+        by_id: String,
+    },
+
     /// Manage config
     Config {
         /// init the config file
@@ -211,6 +218,13 @@ pub fn run() {
                 Err(err) => println!("{}", err.message),
             }
         }
+        Commands::Tweets { by_id } => {
+            let tweet_res = twitter::tweets::TweetLookup::new(by_id).fetch();
+            match tweet_res {
+                Ok(ok) => println!("{}", ok.content),
+                Err(err) => eprintln!("{}", err.message),
+            }
+        }
         Commands::Config {
             edit,
             show,
@@ -350,13 +364,20 @@ pub fn run() {
                 match likes_res {
                     Ok(ok) => {
                         let tweets = ok.content.data;
+                        let includes = ok.content.includes;
                         if tweets.is_empty() {
                             println!("No liked tweets found.");
                             return;
                         }
 
                         for tweet in tweets {
-                            println!("{}\n", twitter::TweetCreateResponse { data: tweet });
+                            println!(
+                                "{}\n",
+                                twitter::TweetCreateResponse {
+                                    data: tweet,
+                                    includes: includes.clone(),
+                                }
+                            );
                         }
                     }
                     Err(err) => eprintln!("{}", err.message),
@@ -377,13 +398,20 @@ pub fn run() {
             match timeline_res {
                 Ok(ok) => {
                     let tweets = ok.content.data;
+                    let includes = ok.content.includes;
                     if tweets.is_empty() {
                         println!("No tweets found in timeline.");
                         return;
                     }
 
                     for tweet in tweets {
-                        println!("{}\n", twitter::TweetCreateResponse { data: tweet });
+                        println!(
+                            "{}\n",
+                            twitter::TweetCreateResponse {
+                                data: tweet,
+                                includes: includes.clone(),
+                            }
+                        );
                     }
                 }
                 Err(err) => eprintln!("{}", err.message),
@@ -403,13 +431,20 @@ pub fn run() {
             match mentions_res {
                 Ok(ok) => {
                     let tweets = ok.content.data;
+                    let includes = ok.content.includes;
                     if tweets.is_empty() {
                         println!("No mentions found.");
                         return;
                     }
 
                     for tweet in tweets {
-                        println!("{}\n", twitter::TweetCreateResponse { data: tweet });
+                        println!(
+                            "{}\n",
+                            twitter::TweetCreateResponse {
+                                data: tweet,
+                                includes: includes.clone(),
+                            }
+                        );
                     }
                 }
                 Err(err) => eprintln!("{}", err.message),

--- a/src/twitter/likes.rs
+++ b/src/twitter/likes.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    twitter::{Response, TweetData},
+    twitter::{AUTHOR_EXPANSION, Includes, Response, TWEET_FIELDS, TweetData, USER_FIELDS},
     utils::oauth_get_header,
 };
 use serde::Deserialize;
@@ -19,6 +19,8 @@ pub struct LikesMeta {
 #[derive(Debug, Deserialize)]
 pub struct LikesResponse {
     pub data: Vec<TweetData>,
+    #[serde(default)]
+    pub includes: Option<Includes>,
     #[allow(dead_code)]
     pub meta: Option<LikesMeta>,
 }
@@ -54,14 +56,24 @@ impl Likes {
     pub fn fetch(&self) -> Result<Response<LikesResponse>, LikesError> {
         let url = self.url();
         let max_results = self.max_results;
-        let auth_params =
-            oauth::ParameterList::new([("max_results", &max_results as &dyn Display)]);
+        let tweet_fields = TWEET_FIELDS.to_string();
+        let user_fields = USER_FIELDS.to_string();
+        let expansions = AUTHOR_EXPANSION.to_string();
+        let auth_params = oauth::ParameterList::new([
+            ("max_results", &max_results as &dyn Display),
+            ("tweet.fields", &tweet_fields as &dyn Display),
+            ("user.fields", &user_fields as &dyn Display),
+            ("expansions", &expansions as &dyn Display),
+        ]);
         let auth_header = oauth_get_header(url.as_str(), &auth_params);
         let max_results_query = max_results.to_string();
 
         let response = curl_rest::Client::default()
             .get()
             .query_param_kv("max_results", max_results_query.as_str())
+            .query_param_kv("tweet.fields", tweet_fields.as_str())
+            .query_param_kv("user.fields", user_fields.as_str())
+            .query_param_kv("expansions", expansions.as_str())
             .header(curl_rest::Header::Authorization(auth_header.into()))
             .send(url.as_str())
             .map_err(|err| LikesError {

--- a/src/twitter/mentions.rs
+++ b/src/twitter/mentions.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    twitter::{Response, TweetData},
+    twitter::{AUTHOR_EXPANSION, Includes, Response, TWEET_FIELDS, TweetData, USER_FIELDS},
     utils::oauth_get_header,
 };
 use serde::Deserialize;
@@ -19,6 +19,8 @@ pub struct MentionsMeta {
 #[derive(Debug, Deserialize)]
 pub struct MentionsResponse {
     pub data: Vec<TweetData>,
+    #[serde(default)]
+    pub includes: Option<Includes>,
     #[allow(dead_code)]
     pub meta: Option<MentionsMeta>,
 }
@@ -54,14 +56,24 @@ impl Mentions {
     pub fn fetch(&self) -> Result<Response<MentionsResponse>, MentionsError> {
         let url = self.url();
         let max_results = self.max_results;
-        let auth_params =
-            oauth::ParameterList::new([("max_results", &max_results as &dyn Display)]);
+        let tweet_fields = TWEET_FIELDS.to_string();
+        let user_fields = USER_FIELDS.to_string();
+        let expansions = AUTHOR_EXPANSION.to_string();
+        let auth_params = oauth::ParameterList::new([
+            ("max_results", &max_results as &dyn Display),
+            ("tweet.fields", &tweet_fields as &dyn Display),
+            ("user.fields", &user_fields as &dyn Display),
+            ("expansions", &expansions as &dyn Display),
+        ]);
         let auth_header = oauth_get_header(url.as_str(), &auth_params);
         let max_results_query = max_results.to_string();
 
         let response = curl_rest::Client::default()
             .get()
             .query_param_kv("max_results", max_results_query.as_str())
+            .query_param_kv("tweet.fields", tweet_fields.as_str())
+            .query_param_kv("user.fields", user_fields.as_str())
+            .query_param_kv("expansions", expansions.as_str())
             .header(curl_rest::Header::Authorization(auth_header.into()))
             .send(url.as_str())
             .map_err(|err| MentionsError {

--- a/src/twitter/mod.rs
+++ b/src/twitter/mod.rs
@@ -7,7 +7,12 @@ pub mod media;
 pub(crate) mod mentions;
 pub(crate) mod timeline;
 pub mod tweet;
+pub(crate) mod tweets;
 pub mod user;
+
+const TWEET_FIELDS: &str = "author_id,created_at";
+const USER_FIELDS: &str = "name,username";
+const AUTHOR_EXPANSION: &str = "author_id";
 
 pub struct Response<T> {
     #[allow(dead_code)]
@@ -15,24 +20,109 @@ pub struct Response<T> {
     pub content: T,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TweetCreateResponse {
     pub data: TweetData,
+    #[serde(default)]
+    pub includes: Option<Includes>,
 }
 
 impl Display for TweetCreateResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Tweet Id: {}\nTweet body: {}",
-            self.data.id, self.data.text
-        )
+        write!(f, "Tweet Id: {}", self.data.id)?;
+
+        if let Some(author) = self.author() {
+            write!(f, "\nUser: {} (@{})", author.name, author.username)?;
+        } else if let Some(author_id) = &self.data.author_id {
+            write!(f, "\nAuthor Id: {}", author_id)?;
+        }
+
+        if let Some(created_at) = &self.data.created_at {
+            write!(f, "\nCreated at: {}", created_at)?;
+        }
+
+        write!(f, "\nTweet body: {}", self.data.text)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl TweetCreateResponse {
+    fn author(&self) -> Option<&UserData> {
+        let author_id = self.data.author_id.as_deref()?;
+        let users = self.includes.as_ref()?.users.as_ref()?;
+        users.iter().find(|user| user.id == author_id)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TweetData {
     pub text: String,
+    #[serde(default)]
     pub edit_history_tweet_ids: Vec<String>,
     pub id: String,
+    #[serde(default)]
+    pub author_id: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Includes {
+    #[serde(default)]
+    pub users: Option<Vec<UserData>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UserData {
+    pub id: String,
+    pub name: String,
+    pub username: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tweet_display_with_author_details() {
+        let response = TweetCreateResponse {
+            data: TweetData {
+                text: "Hello, world".to_string(),
+                edit_history_tweet_ids: vec!["1".to_string()],
+                id: "1".to_string(),
+                author_id: Some("42".to_string()),
+                created_at: Some("2026-03-06T10:00:00.000Z".to_string()),
+            },
+            includes: Some(Includes {
+                users: Some(vec![UserData {
+                    id: "42".to_string(),
+                    name: "Jane Doe".to_string(),
+                    username: "janedoe".to_string(),
+                }]),
+            }),
+        };
+
+        assert_eq!(
+            response.to_string(),
+            "Tweet Id: 1\nUser: Jane Doe (@janedoe)\nCreated at: 2026-03-06T10:00:00.000Z\nTweet body: Hello, world"
+        );
+    }
+
+    #[test]
+    fn test_tweet_display_with_author_id_fallback() {
+        let response = TweetCreateResponse {
+            data: TweetData {
+                text: "Hello, world".to_string(),
+                edit_history_tweet_ids: vec!["1".to_string()],
+                id: "1".to_string(),
+                author_id: Some("42".to_string()),
+                created_at: None,
+            },
+            includes: None,
+        };
+
+        assert_eq!(
+            response.to_string(),
+            "Tweet Id: 1\nAuthor Id: 42\nTweet body: Hello, world"
+        );
+    }
 }

--- a/src/twitter/timeline.rs
+++ b/src/twitter/timeline.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    twitter::{Response, TweetData},
+    twitter::{AUTHOR_EXPANSION, Includes, Response, TWEET_FIELDS, TweetData, USER_FIELDS},
     utils::oauth_get_header,
 };
 use serde::Deserialize;
@@ -19,6 +19,8 @@ pub struct TimelineMeta {
 #[derive(Debug, Deserialize)]
 pub struct TimelineResponse {
     pub data: Vec<TweetData>,
+    #[serde(default)]
+    pub includes: Option<Includes>,
     #[allow(dead_code)]
     pub meta: Option<TimelineMeta>,
 }
@@ -57,14 +59,24 @@ impl Timeline {
     pub fn fetch(&self) -> Result<Response<TimelineResponse>, TimelineError> {
         let url = self.url();
         let max_results = self.max_results;
-        let auth_params =
-            oauth::ParameterList::new([("max_results", &max_results as &dyn Display)]);
+        let tweet_fields = TWEET_FIELDS.to_string();
+        let user_fields = USER_FIELDS.to_string();
+        let expansions = AUTHOR_EXPANSION.to_string();
+        let auth_params = oauth::ParameterList::new([
+            ("max_results", &max_results as &dyn Display),
+            ("tweet.fields", &tweet_fields as &dyn Display),
+            ("user.fields", &user_fields as &dyn Display),
+            ("expansions", &expansions as &dyn Display),
+        ]);
         let auth_header = oauth_get_header(url.as_str(), &auth_params);
         let max_results_query = max_results.to_string();
 
         let response = curl_rest::Client::default()
             .get()
             .query_param_kv("max_results", max_results_query.as_str())
+            .query_param_kv("tweet.fields", tweet_fields.as_str())
+            .query_param_kv("user.fields", user_fields.as_str())
+            .query_param_kv("expansions", expansions.as_str())
             .header(curl_rest::Header::Authorization(auth_header.into()))
             .send(url.as_str())
             .map_err(|err| TimelineError {

--- a/src/twitter/tweet.rs
+++ b/src/twitter/tweet.rs
@@ -154,8 +154,13 @@ impl<'t> TwitterApi for Tweet<'t> {
             text: "".to_string(),
             edit_history_tweet_ids: vec![],
             id: 0.to_string(),
+            author_id: None,
+            created_at: None,
         };
-        let content = TweetCreateResponse { data: tweet_data };
+        let content = TweetCreateResponse {
+            data: tweet_data,
+            includes: None,
+        };
         let mut response = Response {
             status: 200,
             content,

--- a/src/twitter/tweets.rs
+++ b/src/twitter/tweets.rs
@@ -1,0 +1,65 @@
+use crate::{
+    twitter::{AUTHOR_EXPANSION, Response, TWEET_FIELDS, TweetCreateResponse, USER_FIELDS},
+    utils::oauth_get_header,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct TweetLookupError {
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct TweetLookup {
+    tweet_id: String,
+}
+
+impl TweetLookup {
+    pub fn new(tweet_id: impl Into<String>) -> Self {
+        Self {
+            tweet_id: tweet_id.into(),
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/tweets/{}", self.tweet_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<TweetCreateResponse>, TweetLookupError> {
+        let url = self.url();
+        let tweet_fields = TWEET_FIELDS.to_string();
+        let user_fields = USER_FIELDS.to_string();
+        let expansions = AUTHOR_EXPANSION.to_string();
+        let auth_params = oauth::ParameterList::new([
+            ("tweet.fields", &tweet_fields as &dyn std::fmt::Display),
+            ("user.fields", &user_fields as &dyn std::fmt::Display),
+            ("expansions", &expansions as &dyn std::fmt::Display),
+        ]);
+        let auth_header = oauth_get_header(url.as_str(), &auth_params);
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("tweet.fields", tweet_fields.as_str())
+            .query_param_kv("user.fields", user_fields.as_str())
+            .query_param_kv("expansions", expansions.as_str())
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| TweetLookupError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let tweet_data: TweetCreateResponse =
+                serde_json::from_slice(&response.body).map_err(|err| TweetLookupError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: tweet_data,
+            })
+        } else {
+            let err_data = String::from_utf8_lossy(&response.body).to_string();
+            Err(TweetLookupError { message: err_data })
+        }
+    }
+}


### PR DESCRIPTION
**Description**
  Adds read-only tweet retrieval features and improves tweet output formatting. This PR introduces
  support for fetching mentions, liked tweets, and a specific tweet by ID from the X API, and updates
  tweet display output to include richer metadata such as author and creation time when available.

  **Related issue(s)**
  None.

  **Changes introduced**
  - Added twitter mentions, twitter likes tweets, and twitter tweets --by-id <id> commands with matching
    X API client modules
  - Expanded read endpoints to request tweet metadata and author expansions so output can include user
    and timestamp details
  - Updated tweet display rendering and README usage docs for the new commands and richer output

 **How to test**
  Provide valid X API credentials in your config, then run:
```sh
  cargo fmt --check
  cargo test
  twitter mentions
  twitter likes tweets
  twitter tweets --by-id 2006409743426818416
```

  **Checklist**
  - [x] Code compiles and runs
  - [x] Tests added or updated
  - [x] Documentation updated (if applicable)
  - [x] cargo fmt has been run
  - [ ] cargo clippy shows no new warnings

  **Additional context**
  The new read-only commands follow the same structure as the existing timeline implementation: build an
  OAuth-signed request, deserialize tweet data, and print using the shared formatter. The display change
  depends on requesting extra X API fields (author_id, created_at) and author expansions, so timeline,
  mentions, likes, and tweet lookup now all request that metadata consistently.

