### PR TITLE
feat: add liking users lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,15 +410,20 @@ twitter mentions
 ```
 
 ### Likes
-<<<<<<< HEAD
+Show who liked a tweet.
+```bash
+twitter likes by --tweet-id 1234567890
+twitter likes by --tweet-id 1234567890 --max-results 25
+```
+
 Like a tweet for the currently authenticated user.
 ```bash
 twitter likes create --tweet-id 1234567890
-=======
+```
+
 Remove a like for the currently authenticated user.
 ```bash
 twitter likes delete --tweet-id 1234567890
->>>>>>> main
 ```
 
 Fetch tweets liked by the currently authenticated user.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -137,6 +137,17 @@ enum ScheduleEnum {
 
 #[derive(Debug, Subcommand)]
 enum LikesEnum {
+    /// Show the users who liked a tweet
+    By {
+        /// The tweet id
+        #[arg(long)]
+        tweet_id: String,
+
+        /// Number of results to fetch
+        #[arg(long, default_value_t = 10)]
+        max_results: u8,
+    },
+
     /// Like a tweet for the current authenticated user
     Create {
         /// The tweet id to like
@@ -585,6 +596,24 @@ pub fn run() {
             }
         },
         Commands::Likes { command } => match command {
+            LikesEnum::By {
+                tweet_id,
+                max_results,
+            } => {
+                let users = twitter::likes::LikingUsers::new(tweet_id).max_results(max_results);
+
+                match users.fetch() {
+                    Ok(ok) => {
+                        if ok.content.data.is_empty() {
+                            println!("No liking users found.");
+                            return;
+                        }
+
+                        println!("{}", ok.content);
+                    }
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
             LikesEnum::Create { tweet_id } => {
                 let like = twitter::likes::CreateLike::for_current_user(tweet_id);
 

--- a/src/twitter/likes.rs
+++ b/src/twitter/likes.rs
@@ -60,9 +60,45 @@ pub struct DeleteLikeError {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LikingUsersMeta {
+    #[allow(dead_code)]
+    pub result_count: u32,
+    #[allow(dead_code)]
+    pub next_token: Option<String>,
+    #[allow(dead_code)]
+    pub previous_token: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct LikingUser {
+    pub id: String,
+    pub name: String,
+    pub username: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LikingUsersResponse {
+    #[serde(default)]
+    pub data: Vec<LikingUser>,
+    #[allow(dead_code)]
+    pub meta: Option<LikingUsersMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LikingUsersError {
+    pub message: String,
+}
+
 #[derive(Debug)]
 pub struct Likes {
     user_id: String,
+    max_results: u8,
+}
+
+#[derive(Debug)]
+pub struct LikingUsers {
+    tweet_id: String,
     max_results: u8,
 }
 
@@ -139,6 +175,54 @@ impl Likes {
         } else {
             let err_data = String::from_utf8_lossy(&response.body).to_string();
             Err(LikesError { message: err_data })
+        }
+    }
+}
+
+impl LikingUsers {
+    pub fn new(tweet_id: impl Into<String>) -> Self {
+        Self {
+            tweet_id: tweet_id.into(),
+            max_results: 10,
+        }
+    }
+
+    pub fn max_results(mut self, max_results: u8) -> Self {
+        self.max_results = max_results.clamp(1, 100);
+        self
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/tweets/{}/liking_users", self.tweet_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<LikingUsersResponse>, LikingUsersError> {
+        let url = self.url();
+        let max_results = self.max_results.to_string();
+        let auth_header = oauth_get_header(url.as_str(), &());
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("max_results", max_results.as_str())
+            .query_param_kv("user.fields", "name,username")
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| LikingUsersError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let data: LikingUsersResponse =
+                serde_json::from_slice(&response.body).map_err(|err| LikingUsersError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: data,
+            })
+        } else {
+            let err_data = String::from_utf8_lossy(&response.body).to_string();
+            Err(LikingUsersError { message: err_data })
         }
     }
 }
@@ -235,6 +319,25 @@ impl DeleteLike {
     }
 }
 
+impl std::fmt::Display for LikingUsersResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, user) in self.data.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+
+            write!(
+                f,
+                "User Id: {}\nName: {}\nUsername: @{}",
+                user.id, user.name, user.username
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +360,18 @@ mod tests {
         };
 
         assert_eq!(endpoint.url(), "https://api.x.com/2/users/123/likes/456");
+    }
+
+    #[test]
+    fn test_liking_users_url_uses_tweet_id() {
+        let endpoint = LikingUsers {
+            tweet_id: "456".to_string(),
+            max_results: 10,
+        };
+
+        assert_eq!(
+            endpoint.url(),
+            "https://api.x.com/2/tweets/456/liking_users"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add support for GET /2/tweets/:id/liking_users via twitter likes by --tweet-id
- display users who liked a tweet in a plain text format
- document the new likes by command

Closes #82