### PR TITLE
feat: add dm conversation creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ twitter retweets delete --tweet-id 1234567890
 ```
 
 ### DMs
+#### Create a DM conversation
+```bash
+twitter dms create --participant-ids 123456,987654 --text "hello from the CLI"
+```
+
 #### Send a message to an existing conversation
 ```bash
 twitter dms send --conversation-id 1234567890-987654321 --text "hello from the CLI"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -231,6 +231,17 @@ enum ListsEnum {
 
 #[derive(Debug, Subcommand)]
 enum DmsEnum {
+    /// Create a DM conversation and send the initial message
+    Create {
+        /// Comma-separated participant ids
+        #[arg(long, value_delimiter = ',')]
+        participant_ids: Vec<String>,
+
+        /// The initial message text
+        #[arg(long)]
+        text: String,
+    },
+
     /// Send a message to an existing DM conversation
     Send {
         /// The conversation id
@@ -795,6 +806,17 @@ pub fn run() {
             }
         },
         Commands::Dms { command } => match command {
+            DmsEnum::Create {
+                participant_ids,
+                text,
+            } => {
+                let conversation = twitter::dms::CreateConversation::new(participant_ids, text);
+
+                match conversation.send() {
+                    Ok(ok) => println!("{}", ok.content),
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
             DmsEnum::Send {
                 conversation_id,
                 text,

--- a/src/twitter/dms.rs
+++ b/src/twitter/dms.rs
@@ -19,14 +19,44 @@ pub struct SendConversationMessageError {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct CreateConversationData {
+    pub dm_conversation_id: String,
+    pub dm_event_id: String,
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateConversationResponse {
+    pub data: CreateConversationData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateConversationError {
+    pub message: String,
+}
+
 #[derive(Debug)]
 pub struct SendConversationMessage {
     conversation_id: String,
     text: String,
 }
 
+#[derive(Debug)]
+pub struct CreateConversation {
+    participant_ids: Vec<String>,
+    text: String,
+}
+
 #[derive(Serialize)]
 struct SendConversationMessageBody<'a> {
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct CreateConversationBody<'a> {
+    conversation_type: &'static str,
+    participant_ids: &'a [String],
     text: &'a str,
 }
 
@@ -83,7 +113,67 @@ impl SendConversationMessage {
     }
 }
 
+impl CreateConversation {
+    pub fn new(participant_ids: Vec<String>, text: impl Into<String>) -> Self {
+        Self {
+            participant_ids,
+            text: text.into(),
+        }
+    }
+
+    fn url(&self) -> &'static str {
+        "https://api.x.com/2/dm_conversations"
+    }
+
+    pub fn send(&self) -> Result<Response<CreateConversationResponse>, CreateConversationError> {
+        let url = self.url();
+        let auth_header = oauth_post_header(url, &());
+        let body = serde_json::to_string(&CreateConversationBody {
+            conversation_type: "GroupDM",
+            participant_ids: self.participant_ids.as_slice(),
+            text: self.text.as_str(),
+        })
+        .map_err(|err| CreateConversationError {
+            message: err.to_string(),
+        })?;
+
+        let response = curl_rest::Client::default()
+            .post()
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .body_json(body)
+            .send(url)
+            .map_err(|err| CreateConversationError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let data: CreateConversationResponse =
+                serde_json::from_slice(&response.body).map_err(|err| CreateConversationError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: data,
+            })
+        } else {
+            Err(CreateConversationError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
 impl std::fmt::Display for SendConversationMessageResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Conversation Id: {}\nMessage Id: {}\nText: {}",
+            self.data.dm_conversation_id, self.data.dm_event_id, self.data.text
+        )
+    }
+}
+
+impl std::fmt::Display for CreateConversationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -105,5 +195,12 @@ mod tests {
             endpoint.url(),
             "https://api.x.com/2/dm_conversations/123/messages"
         );
+    }
+
+    #[test]
+    fn test_create_conversation_uses_collection_url() {
+        let endpoint = CreateConversation::new(vec!["1".to_string(), "2".to_string()], "hello");
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/dm_conversations");
     }
 }


### PR DESCRIPTION
## Summary
- add support for POST /2/dm_conversations via twitter dms create
- accept comma-separated participant ids and an initial message
- document the new dms create command

Closes #80