### PR TITLE
feat: add user dm events command

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ twitter retweets delete --tweet-id 1234567890
 ```
 
 ### DMs
+#### Show your DM events
+```bash
+twitter dms events
+twitter dms events --max-results 25
+```
+
 #### Create a DM conversation
 ```bash
 twitter dms create --participant-ids 123456,987654 --text "hello from the CLI"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -231,6 +231,13 @@ enum ListsEnum {
 
 #[derive(Debug, Subcommand)]
 enum DmsEnum {
+    /// Show DM events for the current authenticated user
+    Events {
+        /// Number of results to fetch
+        #[arg(long, default_value_t = 10)]
+        max_results: u8,
+    },
+
     /// Create a DM conversation and send the initial message
     Create {
         /// Comma-separated participant ids
@@ -817,6 +824,25 @@ pub fn run() {
             }
         },
         Commands::Dms { command } => match command {
+            DmsEnum::Events { max_results } => {
+                let events = twitter::dms::UserDmEvents::current_user()
+                    .map(|events| events.max_results(max_results));
+
+                match events {
+                    Ok(events) => match events.fetch() {
+                        Ok(ok) => {
+                            if ok.content.data.is_empty() {
+                                println!("No DM events found.");
+                                return;
+                            }
+
+                            println!("{}", ok.content);
+                        }
+                        Err(err) => eprintln!("{}", err.message),
+                    },
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
             DmsEnum::Create {
                 participant_ids,
                 text,

--- a/src/twitter/dms.rs
+++ b/src/twitter/dms.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{twitter::Response, utils::oauth_post_header};
+use crate::{
+    twitter::Response,
+    utils::{get_current_user_id, oauth_get_header, oauth_post_header},
+};
 
 #[derive(Debug, Deserialize)]
 pub struct SendConversationMessageData {
@@ -53,10 +56,46 @@ pub struct SendWithParticipantMessageError {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct UserDmEvent {
+    pub dm_conversation_id: String,
+    pub dm_event_id: String,
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserDmEventsMeta {
+    #[allow(dead_code)]
+    pub result_count: u32,
+    #[allow(dead_code)]
+    pub next_token: Option<String>,
+    #[allow(dead_code)]
+    pub previous_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserDmEventsResponse {
+    #[serde(default)]
+    pub data: Vec<UserDmEvent>,
+    #[allow(dead_code)]
+    pub meta: Option<UserDmEventsMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserDmEventsError {
+    pub message: String,
+}
+
 #[derive(Debug)]
 pub struct SendConversationMessage {
     conversation_id: String,
     text: String,
+}
+
+#[derive(Debug)]
+pub struct UserDmEvents {
+    user_id: String,
+    max_results: u8,
 }
 
 #[derive(Debug)]
@@ -130,6 +169,55 @@ impl SendConversationMessage {
             })
         } else {
             Err(SendConversationMessageError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
+impl UserDmEvents {
+    pub fn current_user() -> Result<Self, UserDmEventsError> {
+        let user_id = get_current_user_id().map_err(|message| UserDmEventsError { message })?;
+        Ok(Self {
+            user_id,
+            max_results: 10,
+        })
+    }
+
+    pub fn max_results(mut self, max_results: u8) -> Self {
+        self.max_results = max_results.clamp(1, 100);
+        self
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/users/{}/dm_events", self.user_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<UserDmEventsResponse>, UserDmEventsError> {
+        let url = self.url();
+        let max_results = self.max_results.to_string();
+        let auth_header = oauth_get_header(url.as_str(), &());
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("max_results", max_results.as_str())
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| UserDmEventsError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let data: UserDmEventsResponse =
+                serde_json::from_slice(&response.body).map_err(|err| UserDmEventsError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: data,
+            })
+        } else {
+            Err(UserDmEventsError {
                 message: String::from_utf8_lossy(&response.body).to_string(),
             })
         }
@@ -271,6 +359,25 @@ impl std::fmt::Display for SendWithParticipantMessageResponse {
     }
 }
 
+impl std::fmt::Display for UserDmEventsResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, event) in self.data.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+
+            write!(
+                f,
+                "Conversation Id: {}\nMessage Id: {}\nText: {}",
+                event.dm_conversation_id, event.dm_event_id, event.text
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,5 +407,15 @@ mod tests {
             endpoint.url(),
             "https://api.x.com/2/dm_conversations/with/123/messages"
         );
+    }
+
+    #[test]
+    fn test_user_dm_events_url_uses_current_user_id() {
+        let endpoint = UserDmEvents {
+            user_id: "123".to_string(),
+            max_results: 10,
+        };
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/users/123/dm_events");
     }
 }


### PR DESCRIPTION
## Summary
- add support for GET /2/users/:id/dm_events via twitter dms events
- default the user-scoped lookup to the current authenticated user
- document the new dms events command

Closes #78