### PR TITLE
Add support for deleting any list member

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -231,6 +231,10 @@ enum ListsEnum {
         /// The list id
         #[arg(long)]
         list_id: String,
+
+        /// The user id to remove. Defaults to the current authenticated user.
+        #[arg(long)]
+        user_id: Option<String>,
     },
 
     /// Fetch the lists the current authenticated user belongs to
@@ -854,16 +858,19 @@ pub fn run() {
                     Err(err) => eprintln!("{}", err.message),
                 }
             }
-            ListsEnum::RemoveMember { list_id } => {
-                let remove = twitter::lists::DeleteListMember::for_current_user(list_id);
+            ListsEnum::RemoveMember { list_id, user_id } => {
+                let remove = match user_id {
+                    Some(user_id) => Ok(twitter::lists::DeleteListMember::new(list_id, user_id)),
+                    None => twitter::lists::DeleteListMember::for_current_user(list_id),
+                };
 
                 match remove {
                     Ok(remove) => match remove.send() {
                         Ok(ok) => {
                             if ok.content.data.is_member {
-                                eprintln!("Current user is still a member of the list.");
+                                eprintln!("User is still a member of the list.");
                             } else {
-                                println!("Removed current user from the list.");
+                                println!("Removed user from the list.");
                             }
                         }
                         Err(err) => eprintln!("{}", err.message),

--- a/src/twitter/lists.rs
+++ b/src/twitter/lists.rs
@@ -393,12 +393,16 @@ impl ListMembers {
 }
 
 impl DeleteListMember {
+    pub fn new(list_id: impl Into<String>, user_id: impl Into<String>) -> Self {
+        Self {
+            list_id: list_id.into(),
+            user_id: user_id.into(),
+        }
+    }
+
     pub fn for_current_user(list_id: impl Into<String>) -> Result<Self, DeleteListMemberError> {
         let user_id = get_current_user_id().map_err(|message| DeleteListMemberError { message })?;
-        Ok(Self {
-            list_id: list_id.into(),
-            user_id,
-        })
+        Ok(Self::new(list_id, user_id))
     }
 
     fn url(&self) -> String {


### PR DESCRIPTION
## Summary
- add a general constructor for DELETE /2/lists/:id/members/:user_id
- allow the list member removal command to target an explicit user id while keeping the current-user helper
- keep list member removal messaging generic for either path

Closes #97