### PR TITLE
Add support for adding members to lists

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -226,6 +226,17 @@ enum ListsEnum {
         max_results: u8,
     },
 
+    /// Add a user to a list
+    AddMember {
+        /// The list id
+        #[arg(long)]
+        list_id: String,
+
+        /// The user id to add
+        #[arg(long)]
+        user_id: String,
+    },
+
     /// Remove the current authenticated user from a list
     RemoveMember {
         /// The list id
@@ -850,6 +861,20 @@ pub fn run() {
                         }
 
                         println!("{}", ok.content);
+                    }
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
+            ListsEnum::AddMember { list_id, user_id } => {
+                let add = twitter::lists::CreateListMember::new(list_id, user_id);
+
+                match add.send() {
+                    Ok(ok) => {
+                        if ok.content.data.is_member {
+                            println!("Added user to the list.");
+                        } else {
+                            eprintln!("User was not added to the list.");
+                        }
                     }
                     Err(err) => eprintln!("{}", err.message),
                 }

--- a/src/twitter/lists.rs
+++ b/src/twitter/lists.rs
@@ -88,6 +88,21 @@ pub struct CreateListError {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct CreateListMemberData {
+    pub is_member: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateListMemberResponse {
+    pub data: CreateListMemberData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateListMemberError {
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ListMembersMeta {
     #[allow(dead_code)]
     pub result_count: u32,
@@ -126,6 +141,12 @@ pub struct CreateList {
     name: String,
     description: Option<String>,
     private: Option<bool>,
+}
+
+#[derive(Debug)]
+pub struct CreateListMember {
+    list_id: String,
+    user_id: String,
 }
 
 #[derive(Debug)]
@@ -182,6 +203,11 @@ struct CreateListBody<'a> {
     description: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     private: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct CreateListMemberBody<'a> {
+    user_id: &'a str,
 }
 
 impl ListMemberships {
@@ -337,6 +363,54 @@ impl CreateList {
             })
         } else {
             Err(CreateListError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
+impl CreateListMember {
+    pub fn new(list_id: impl Into<String>, user_id: impl Into<String>) -> Self {
+        Self {
+            list_id: list_id.into(),
+            user_id: user_id.into(),
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/lists/{}/members", self.list_id)
+    }
+
+    pub fn send(&self) -> Result<Response<CreateListMemberResponse>, CreateListMemberError> {
+        let url = self.url();
+        let auth_header = oauth_post_header(url.as_str(), &());
+        let body = serde_json::to_string(&CreateListMemberBody {
+            user_id: self.user_id.as_str(),
+        })
+        .map_err(|err| CreateListMemberError {
+            message: err.to_string(),
+        })?;
+
+        let response = curl_rest::Client::default()
+            .post()
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .body_json(body)
+            .send(url.as_str())
+            .map_err(|err| CreateListMemberError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let data: CreateListMemberResponse =
+                serde_json::from_slice(&response.body).map_err(|err| CreateListMemberError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: data,
+            })
+        } else {
+            Err(CreateListMemberError {
                 message: String::from_utf8_lossy(&response.body).to_string(),
             })
         }
@@ -588,6 +662,13 @@ mod tests {
         let endpoint = CreateList::new("cli-builders");
 
         assert_eq!(endpoint.url(), "https://api.x.com/2/lists");
+    }
+
+    #[test]
+    fn test_create_list_member_url_uses_list_id() {
+        let endpoint = CreateListMember::new("123", "456");
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/lists/123/members");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a POST /2/lists/:id/members request wrapper and response types
- expose a lists add-member CLI command for targeting a list and user id
- cover the new endpoint URL with a unit test

Closes #96