### PR TITLE
Add support for looking up users by id

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,6 +127,12 @@ enum Commands {
     /// Mentions
     Mentions {},
 
+    /// Users
+    Users {
+        #[command(subcommand)]
+        command: UsersEnum,
+    },
+
     /// Show information about the current authenticated user
     Me {},
 }
@@ -426,6 +432,16 @@ enum TweetsEnum {
         /// Number of results to fetch
         #[arg(long, default_value_t = 10)]
         max_results: u16,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum UsersEnum {
+    /// Fetch a user by id
+    ById {
+        /// The id of the user to fetch
+        #[arg(long)]
+        id: String,
     },
 }
 
@@ -1229,6 +1245,15 @@ pub fn run() {
                 Err(err) => eprintln!("{}", err.message),
             }
         }
+        Commands::Users { command } => match command {
+            UsersEnum::ById { id } => {
+                let user = twitter::user::UserLookup::new(id).fetch();
+                match user {
+                    Ok(ok) => println!("{}", ok.content),
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
+        },
         Commands::Me {} => {
             let me_res = twitter::user::me();
             match me_res {

--- a/src/twitter/user.rs
+++ b/src/twitter/user.rs
@@ -21,6 +21,21 @@ pub struct CurrentUserError {
     pub message: String,
 }
 
+#[derive(Debug)]
+pub struct UserLookup {
+    user_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserLookupResponse {
+    pub data: CurrentUserData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserLookupError {
+    pub message: String,
+}
+
 impl Display for CurrentUserResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -28,6 +43,56 @@ impl Display for CurrentUserResponse {
             "User Id: {}\nName: {}\nUsername: @{}",
             self.data.id, self.data.name, self.data.username
         )
+    }
+}
+
+impl Display for UserLookupResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "User Id: {}\nName: {}\nUsername: @{}",
+            self.data.id, self.data.name, self.data.username
+        )
+    }
+}
+
+impl UserLookup {
+    pub fn new(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/users/{}", self.user_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<UserLookupResponse>, UserLookupError> {
+        let url = self.url();
+        let auth_header = oauth_get_header(url.as_str(), &());
+
+        let response = curl_rest::Client::default()
+            .get()
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| UserLookupError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let user_data: UserLookupResponse =
+                serde_json::from_slice(&response.body).map_err(|err| UserLookupError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: user_data,
+            })
+        } else {
+            Err(UserLookupError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
     }
 }
 
@@ -56,5 +121,17 @@ pub fn me() -> Result<Response<CurrentUserResponse>, CurrentUserError> {
         Err(CurrentUserError {
             message: String::from_utf8_lossy(&response.body).to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_lookup_url_uses_user_id() {
+        let endpoint = UserLookup::new("123");
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/users/123");
     }
 }


### PR DESCRIPTION
## Summary
- add a GET /2/users/:id request wrapper in the user module
- expose a users by-id CLI command
- cover the user lookup endpoint URL with a unit test

Closes #61