### PR TITLE
fix: sign query params for blocks list

### DIFF
--- a/src/twitter/blocks.rs
+++ b/src/twitter/blocks.rs
@@ -109,12 +109,17 @@ impl BlockedUsers {
     pub fn fetch(&self) -> Result<Response<BlockedUsersResponse>, BlockedUsersError> {
         let url = self.url();
         let max_results = self.max_results.to_string();
-        let auth_header = oauth_get_header(url.as_str(), &());
+        let user_fields = "name,username".to_string();
+        let auth_params = oauth::ParameterList::new([
+            ("max_results", &max_results as &dyn std::fmt::Display),
+            ("user.fields", &user_fields as &dyn std::fmt::Display),
+        ]);
+        let auth_header = oauth_get_header(url.as_str(), &auth_params);
 
         let response = curl_rest::Client::default()
             .get()
             .query_param_kv("max_results", max_results.as_str())
-            .query_param_kv("user.fields", "name,username")
+            .query_param_kv("user.fields", user_fields.as_str())
             .header(curl_rest::Header::Authorization(auth_header.into()))
             .send(url.as_str())
             .map_err(|err| BlockedUsersError {


### PR DESCRIPTION
## Summary
- fix `twitter blocks list` so the OAuth 1.0a signature includes `max_results` and `user.fields`
- keep the endpoint on user-context auth instead of switching to the app-only bearer token
- close the auth failure reported in #142

## Verification
- `cargo test`
- `cargo run -- blocks list --max-results 5`
