### PR TITLE
Fix bearer auth for blocked users lookup

### DIFF
--- a/src/twitter/blocks.rs
+++ b/src/twitter/blocks.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     twitter::Response,
-    utils::{get_current_user_id, oauth_get_header, oauth_post_header},
+    utils::{bearer_auth_header, get_current_user_id, oauth_post_header},
 };
 
 #[derive(Debug, Deserialize)]
@@ -106,21 +106,21 @@ impl BlockedUsers {
         format!("https://api.x.com/2/users/{}/blocking", self.user_id)
     }
 
+    fn authorization_header(&self) -> String {
+        bearer_auth_header()
+    }
+
     pub fn fetch(&self) -> Result<Response<BlockedUsersResponse>, BlockedUsersError> {
         let url = self.url();
         let max_results = self.max_results.to_string();
-        let user_fields = "name,username".to_string();
-        let auth_params = oauth::ParameterList::new([
-            ("max_results", &max_results as &dyn std::fmt::Display),
-            ("user.fields", &user_fields as &dyn std::fmt::Display),
-        ]);
-        let auth_header = oauth_get_header(url.as_str(), &auth_params);
+        let user_fields = "name,username";
+        let authorization = self.authorization_header();
 
         let response = curl_rest::Client::default()
             .get()
             .query_param_kv("max_results", max_results.as_str())
-            .query_param_kv("user.fields", user_fields.as_str())
-            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .query_param_kv("user.fields", user_fields)
+            .header(curl_rest::Header::Authorization(authorization.into()))
             .send(url.as_str())
             .map_err(|err| BlockedUsersError {
                 message: err.to_string(),
@@ -269,6 +269,16 @@ mod tests {
         };
 
         assert_eq!(endpoint.url(), "https://api.x.com/2/users/42/blocking");
+    }
+
+    #[test]
+    fn test_blocked_users_fetch_uses_bearer_auth_header() {
+        let endpoint = BlockedUsers {
+            user_id: "42".to_string(),
+            max_results: 10,
+        };
+
+        assert!(endpoint.authorization_header().starts_with("Bearer "));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- switch blocked users lookup to bearer auth
- keep block create/delete on OAuth user auth
- add a regression test covering the blocked-users auth header

Fixes #141