### PR TITLE
Add support for looking up users by ids

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -516,6 +516,13 @@ enum UsersEnum {
         #[arg(long)]
         id: String,
     },
+
+    /// Fetch multiple users by ids
+    ByIds {
+        /// Comma-separated user ids
+        #[arg(long, value_delimiter = ',')]
+        ids: Vec<String>,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -1483,6 +1490,20 @@ pub fn run() {
                 let user = twitter::user::UserLookup::new(id).fetch();
                 match user {
                     Ok(ok) => println!("{}", ok.content),
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
+            UsersEnum::ByIds { ids } => {
+                let users = twitter::user::UsersLookup::new(ids).fetch();
+                match users {
+                    Ok(ok) => {
+                        if ok.content.data.is_empty() {
+                            println!("No users found.");
+                            return;
+                        }
+
+                        println!("{}", ok.content);
+                    }
                     Err(err) => eprintln!("{}", err.message),
                 }
             }

--- a/src/twitter/user.rs
+++ b/src/twitter/user.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use crate::{twitter::Response, utils::oauth_get_header};
 
 #[derive(Debug, Deserialize)]
-pub struct CurrentUserData {
+pub struct UserData {
     pub id: String,
     pub name: String,
     pub username: String,
@@ -13,7 +13,7 @@ pub struct CurrentUserData {
 
 #[derive(Debug, Deserialize)]
 pub struct CurrentUserResponse {
-    pub data: CurrentUserData,
+    pub data: UserData,
 }
 
 #[derive(Debug, Deserialize)]
@@ -26,13 +26,29 @@ pub struct UserLookup {
     user_id: String,
 }
 
+#[derive(Debug)]
+pub struct UsersLookup {
+    user_ids: Vec<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct UserLookupResponse {
-    pub data: CurrentUserData,
+    pub data: UserData,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct UserLookupError {
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UsersLookupResponse {
+    #[serde(default)]
+    pub data: Vec<UserData>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UsersLookupError {
     pub message: String,
 }
 
@@ -53,6 +69,25 @@ impl Display for UserLookupResponse {
             "User Id: {}\nName: {}\nUsername: @{}",
             self.data.id, self.data.name, self.data.username
         )
+    }
+}
+
+impl Display for UsersLookupResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, user) in self.data.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+
+            write!(
+                f,
+                "User Id: {}\nName: {}\nUsername: @{}",
+                user.id, user.name, user.username
+            )?;
+        }
+
+        Ok(())
     }
 }
 
@@ -96,6 +131,47 @@ impl UserLookup {
     }
 }
 
+impl UsersLookup {
+    pub fn new(user_ids: Vec<String>) -> Self {
+        Self { user_ids }
+    }
+
+    fn url(&self) -> &'static str {
+        "https://api.x.com/2/users"
+    }
+
+    pub fn fetch(&self) -> Result<Response<UsersLookupResponse>, UsersLookupError> {
+        let url = self.url();
+        let ids = self.user_ids.join(",");
+        let auth_params = oauth::ParameterList::new([("ids", &ids as &dyn Display)]);
+        let auth_header = oauth_get_header(url, &auth_params);
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("ids", ids.as_str())
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url)
+            .map_err(|err| UsersLookupError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let user_data: UsersLookupResponse =
+                serde_json::from_slice(&response.body).map_err(|err| UsersLookupError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: user_data,
+            })
+        } else {
+            Err(UsersLookupError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
 pub fn me() -> Result<Response<CurrentUserResponse>, CurrentUserError> {
     let url = "https://api.x.com/2/users/me";
     let auth_header = oauth_get_header(url, &());
@@ -133,5 +209,35 @@ mod tests {
         let endpoint = UserLookup::new("123");
 
         assert_eq!(endpoint.url(), "https://api.x.com/2/users/123");
+    }
+
+    #[test]
+    fn test_users_lookup_url_uses_collection_endpoint() {
+        let endpoint = UsersLookup::new(vec!["123".to_string(), "456".to_string()]);
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/users");
+    }
+
+    #[test]
+    fn test_users_lookup_display_renders_multiple_users() {
+        let response = UsersLookupResponse {
+            data: vec![
+                UserData {
+                    id: "123".to_string(),
+                    name: "Jane Doe".to_string(),
+                    username: "janedoe".to_string(),
+                },
+                UserData {
+                    id: "456".to_string(),
+                    name: "John Doe".to_string(),
+                    username: "johndoe".to_string(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            response.to_string(),
+            "User Id: 123\nName: Jane Doe\nUsername: @janedoe\n\nUser Id: 456\nName: John Doe\nUsername: @johndoe"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a users collection lookup client for 
- wire a new  command into the CLI
- add URL and display coverage for multi-user lookups

Fixes #62