### PR TITLE
Add support for looking up followers

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -548,6 +548,17 @@ enum UsersEnum {
         #[arg(long, default_value_t = 10)]
         max_results: u8,
     },
+
+    /// Fetch a user's followers
+    Followers {
+        /// The user id to fetch
+        #[arg(long)]
+        id: String,
+
+        /// Number of results to fetch
+        #[arg(long, default_value_t = 10)]
+        max_results: u8,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -1561,6 +1572,22 @@ pub fn run() {
                     Ok(ok) => {
                         if ok.content.data.is_empty() {
                             println!("No following users found.");
+                            return;
+                        }
+
+                        println!("{}", ok.content);
+                    }
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
+            UsersEnum::Followers { id, max_results } => {
+                let users = twitter::follows::Followers::new(id)
+                    .max_results(max_results)
+                    .fetch();
+                match users {
+                    Ok(ok) => {
+                        if ok.content.data.is_empty() {
+                            println!("No followers found.");
                             return;
                         }
 

--- a/src/twitter/follows.rs
+++ b/src/twitter/follows.rs
@@ -28,8 +28,37 @@ pub struct FollowingError {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct FollowersMeta {
+    #[allow(dead_code)]
+    pub result_count: u32,
+    #[allow(dead_code)]
+    pub next_token: Option<String>,
+    #[allow(dead_code)]
+    pub previous_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FollowersResponse {
+    #[serde(default)]
+    pub data: Vec<UserData>,
+    #[allow(dead_code)]
+    pub meta: Option<FollowersMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FollowersError {
+    pub message: String,
+}
+
 #[derive(Debug)]
 pub struct Following {
+    user_id: String,
+    max_results: u8,
+}
+
+#[derive(Debug)]
+pub struct Followers {
     user_id: String,
     max_results: u8,
 }
@@ -107,6 +136,79 @@ impl Following {
     }
 }
 
+impl Display for FollowersResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, user) in self.data.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+
+            write!(
+                f,
+                "User Id: {}\nName: {}\nUsername: @{}",
+                user.id, user.name, user.username
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Followers {
+    pub fn new(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+            max_results: 10,
+        }
+    }
+
+    pub fn max_results(mut self, max_results: u8) -> Self {
+        self.max_results = max_results.clamp(1, 100);
+        self
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/users/{}/followers", self.user_id)
+    }
+
+    pub fn fetch(&self) -> Result<Response<FollowersResponse>, FollowersError> {
+        let url = self.url();
+        let max_results = self.max_results.to_string();
+        let user_fields = "name,username".to_string();
+        let auth_params = oauth::ParameterList::new([
+            ("max_results", &max_results as &dyn Display),
+            ("user.fields", &user_fields as &dyn Display),
+        ]);
+        let auth_header = oauth_get_header(url.as_str(), &auth_params);
+
+        let response = curl_rest::Client::default()
+            .get()
+            .query_param_kv("max_results", max_results.as_str())
+            .query_param_kv("user.fields", user_fields.as_str())
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .send(url.as_str())
+            .map_err(|err| FollowersError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let user_data: FollowersResponse =
+                serde_json::from_slice(&response.body).map_err(|err| FollowersError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: user_data,
+            })
+        } else {
+            Err(FollowersError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +218,12 @@ mod tests {
         let endpoint = Following::new("123");
 
         assert_eq!(endpoint.url(), "https://api.x.com/2/users/123/following");
+    }
+
+    #[test]
+    fn test_followers_url_uses_user_id() {
+        let endpoint = Followers::new("123");
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/users/123/followers");
     }
 }


### PR DESCRIPTION
## Summary
- add a followers lookup client for GET /2/users/:id/followers
- wire a new twitter users followers command into the CLI
- add URL coverage for the followers endpoint

Fixes #67