### PR TITLE
Add support for following a user

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -559,6 +559,13 @@ enum UsersEnum {
         #[arg(long, default_value_t = 10)]
         max_results: u8,
     },
+
+    /// Follow a user for the current authenticated user
+    Follow {
+        /// The target user id to follow
+        #[arg(long)]
+        target_user_id: String,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -1593,6 +1600,23 @@ pub fn run() {
 
                         println!("{}", ok.content);
                     }
+                    Err(err) => eprintln!("{}", err.message),
+                }
+            }
+            UsersEnum::Follow { target_user_id } => {
+                let follow = twitter::follows::CreateFollow::for_current_user(target_user_id);
+
+                match follow {
+                    Ok(follow) => match follow.send() {
+                        Ok(ok) => {
+                            if ok.content.data.following || ok.content.data.pending_follow {
+                                println!("Follow request sent.");
+                            } else {
+                                eprintln!("User was not followed.");
+                            }
+                        }
+                        Err(err) => eprintln!("{}", err.message),
+                    },
                     Err(err) => eprintln!("{}", err.message),
                 }
             }

--- a/src/twitter/follows.rs
+++ b/src/twitter/follows.rs
@@ -1,8 +1,9 @@
 use crate::{
     twitter::{Response, UserData},
-    utils::oauth_get_header,
+    utils::{get_current_user_id, oauth_get_header, oauth_post_header},
 };
 use serde::Deserialize;
+use serde::Serialize;
 use std::fmt::Display;
 
 #[derive(Debug, Deserialize)]
@@ -61,6 +62,33 @@ pub struct Following {
 pub struct Followers {
     user_id: String,
     max_results: u8,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateFollowData {
+    pub following: bool,
+    pub pending_follow: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateFollowResponse {
+    pub data: CreateFollowData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateFollowError {
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct CreateFollow {
+    user_id: String,
+    target_user_id: String,
+}
+
+#[derive(Serialize)]
+struct CreateFollowBody<'a> {
+    target_user_id: &'a str,
 }
 
 impl Display for FollowingResponse {
@@ -209,6 +237,55 @@ impl Followers {
     }
 }
 
+impl CreateFollow {
+    pub fn for_current_user(target_user_id: impl Into<String>) -> Result<Self, CreateFollowError> {
+        let user_id = get_current_user_id().map_err(|message| CreateFollowError { message })?;
+        Ok(Self {
+            user_id,
+            target_user_id: target_user_id.into(),
+        })
+    }
+
+    fn url(&self) -> String {
+        format!("https://api.x.com/2/users/{}/following", self.user_id)
+    }
+
+    pub fn send(&self) -> Result<Response<CreateFollowResponse>, CreateFollowError> {
+        let url = self.url();
+        let auth_header = oauth_post_header(url.as_str(), &());
+        let body = serde_json::to_string(&CreateFollowBody {
+            target_user_id: self.target_user_id.as_str(),
+        })
+        .map_err(|err| CreateFollowError {
+            message: err.to_string(),
+        })?;
+
+        let response = curl_rest::Client::default()
+            .post()
+            .header(curl_rest::Header::Authorization(auth_header.into()))
+            .body_json(body)
+            .send(url.as_str())
+            .map_err(|err| CreateFollowError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let follow_data: CreateFollowResponse = serde_json::from_slice(&response.body)
+                .map_err(|err| CreateFollowError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: follow_data,
+            })
+        } else {
+            Err(CreateFollowError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,5 +302,15 @@ mod tests {
         let endpoint = Followers::new("123");
 
         assert_eq!(endpoint.url(), "https://api.x.com/2/users/123/followers");
+    }
+
+    #[test]
+    fn test_create_follow_url_uses_current_user_id() {
+        let endpoint = CreateFollow {
+            user_id: "123".to_string(),
+            target_user_id: "456".to_string(),
+        };
+
+        assert_eq!(endpoint.url(), "https://api.x.com/2/users/123/following");
     }
 }


### PR DESCRIPTION
## Summary
- add a follow client for POST /2/users/:id/following
- wire a new twitter users follow command into the CLI
- add URL coverage for the follow endpoint

Fixes #68