### PR TITLE
Add support for listing stream rules

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -132,6 +132,12 @@ enum Commands {
     /// Mentions
     Mentions {},
 
+    /// Filtered stream
+    Streams {
+        #[command(subcommand)]
+        command: StreamsEnum,
+    },
+
     /// Users
     Users {
         #[command(subcommand)]
@@ -621,6 +627,21 @@ enum UsersEnum {
         #[arg(long)]
         target_user_id: String,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum StreamsEnum {
+    /// Manage filtered stream rules
+    Rules {
+        #[command(subcommand)]
+        command: StreamRulesEnum,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum StreamRulesEnum {
+    /// List active stream rules
+    List {},
 }
 
 #[derive(Debug, clap::Args)]
@@ -1699,6 +1720,25 @@ pub fn run() {
                 Err(err) => eprintln!("{}", err.message),
             }
         }
+        Commands::Streams { command } => match command {
+            StreamsEnum::Rules { command } => match command {
+                StreamRulesEnum::List {} => {
+                    let rules = twitter::streams::StreamRules.fetch();
+
+                    match rules {
+                        Ok(ok) => {
+                            if ok.content.data.is_empty() {
+                                println!("No stream rules found.");
+                                return;
+                            }
+
+                            println!("{}", ok.content);
+                        }
+                        Err(err) => eprintln!("{}", err.message),
+                    }
+                }
+            },
+        },
         Commands::Users { command } => match command {
             UsersEnum::ById { id } => {
                 let user = twitter::user::UserLookup::new(id).fetch();

--- a/src/twitter/mod.rs
+++ b/src/twitter/mod.rs
@@ -12,6 +12,7 @@ pub mod media;
 pub(crate) mod mentions;
 pub(crate) mod mutes;
 pub(crate) mod retweets;
+pub(crate) mod streams;
 pub(crate) mod timeline;
 pub mod tweet;
 pub(crate) mod tweets;

--- a/src/twitter/streams.rs
+++ b/src/twitter/streams.rs
@@ -1,0 +1,103 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{twitter::Response, utils::bearer_auth_header};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StreamRule {
+    pub id: String,
+    pub value: String,
+    #[serde(default)]
+    pub tag: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamRulesMeta {
+    #[allow(dead_code)]
+    pub sent: Option<String>,
+    #[allow(dead_code)]
+    pub result_count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamRulesResponse {
+    #[serde(default)]
+    pub data: Vec<StreamRule>,
+    #[allow(dead_code)]
+    pub meta: Option<StreamRulesMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamRulesError {
+    pub message: String,
+}
+
+pub struct StreamRules;
+
+impl Display for StreamRulesResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, rule) in self.data.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+
+            write!(f, "Rule Id: {}\nValue: {}", rule.id, rule.value)?;
+            if let Some(tag) = &rule.tag {
+                write!(f, "\nTag: {}", tag)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl StreamRules {
+    fn url(&self) -> &'static str {
+        "https://api.x.com/2/tweets/search/stream/rules"
+    }
+
+    pub fn fetch(&self) -> Result<Response<StreamRulesResponse>, StreamRulesError> {
+        let url = self.url();
+        let authorization = bearer_auth_header();
+
+        let response = curl_rest::Client::default()
+            .get()
+            .header(curl_rest::Header::Authorization(authorization.into()))
+            .send(url)
+            .map_err(|err| StreamRulesError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let rules_data: StreamRulesResponse =
+                serde_json::from_slice(&response.body).map_err(|err| StreamRulesError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: rules_data,
+            })
+        } else {
+            Err(StreamRulesError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stream_rules_url_uses_rules_endpoint() {
+        let endpoint = StreamRules;
+
+        assert_eq!(
+            endpoint.url(),
+            "https://api.x.com/2/tweets/search/stream/rules"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a filtered stream rules client for GET /2/tweets/search/stream/rules
- wire a new twitter streams rules list command into the CLI
- add URL coverage for the stream rules endpoint

Fixes #49