### PR TITLE
Add support for updating stream rules

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -642,6 +642,24 @@ enum StreamsEnum {
 enum StreamRulesEnum {
     /// List active stream rules
     List {},
+
+    /// Add a stream rule
+    Add {
+        /// The rule value
+        #[arg(long)]
+        value: String,
+
+        /// Optional rule tag
+        #[arg(long)]
+        tag: Option<String>,
+    },
+
+    /// Delete stream rules by ids
+    Delete {
+        /// Comma-separated rule ids
+        #[arg(long, value_delimiter = ',')]
+        ids: Vec<String>,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -1734,6 +1752,28 @@ pub fn run() {
 
                             println!("{}", ok.content);
                         }
+                        Err(err) => eprintln!("{}", err.message),
+                    }
+                }
+                StreamRulesEnum::Add { value, tag } => {
+                    let create = twitter::streams::AddStreamRule::new(value, tag);
+
+                    match create.send() {
+                        Ok(ok) => {
+                            if ok.content.data.is_empty() {
+                                println!("Stream rule request sent.");
+                            } else {
+                                println!("{}", ok.content.data[0].value);
+                            }
+                        }
+                        Err(err) => eprintln!("{}", err.message),
+                    }
+                }
+                StreamRulesEnum::Delete { ids } => {
+                    let delete = twitter::streams::DeleteStreamRules::new(ids);
+
+                    match delete.send() {
+                        Ok(_) => println!("Deleted stream rules."),
                         Err(err) => eprintln!("{}", err.message),
                     }
                 }

--- a/src/twitter/streams.rs
+++ b/src/twitter/streams.rs
@@ -33,7 +33,59 @@ pub struct StreamRulesError {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct StreamRulesUpdateMeta {
+    #[allow(dead_code)]
+    pub summary: Option<serde_json::Value>,
+    #[allow(dead_code)]
+    pub sent: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamRulesUpdateResponse {
+    #[serde(default)]
+    pub data: Vec<StreamRule>,
+    #[allow(dead_code)]
+    pub meta: Option<StreamRulesUpdateMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamRulesUpdateError {
+    pub message: String,
+}
+
 pub struct StreamRules;
+
+#[derive(Debug)]
+pub struct AddStreamRule {
+    value: String,
+    tag: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct DeleteStreamRules {
+    ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AddStreamRulePayload<'a> {
+    value: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tag: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+struct DeleteStreamRulesPayload<'a> {
+    ids: &'a [String],
+}
+
+#[derive(Debug, Serialize)]
+struct StreamRulesUpdatePayload<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    add: Option<Vec<AddStreamRulePayload<'a>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delete: Option<DeleteStreamRulesPayload<'a>>,
+}
 
 impl Display for StreamRulesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -87,6 +139,106 @@ impl StreamRules {
     }
 }
 
+impl AddStreamRule {
+    pub fn new(value: impl Into<String>, tag: Option<String>) -> Self {
+        Self {
+            value: value.into(),
+            tag,
+        }
+    }
+
+    fn url(&self) -> &'static str {
+        "https://api.x.com/2/tweets/search/stream/rules"
+    }
+
+    pub fn send(&self) -> Result<Response<StreamRulesUpdateResponse>, StreamRulesUpdateError> {
+        let url = self.url();
+        let authorization = bearer_auth_header();
+        let body = serde_json::to_string(&StreamRulesUpdatePayload {
+            add: Some(vec![AddStreamRulePayload {
+                value: self.value.as_str(),
+                tag: self.tag.as_deref(),
+            }]),
+            delete: None,
+        })
+        .map_err(|err| StreamRulesUpdateError {
+            message: err.to_string(),
+        })?;
+
+        let response = curl_rest::Client::default()
+            .post()
+            .header(curl_rest::Header::Authorization(authorization.into()))
+            .body_json(body)
+            .send(url)
+            .map_err(|err| StreamRulesUpdateError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let rules_data: StreamRulesUpdateResponse = serde_json::from_slice(&response.body)
+                .map_err(|err| StreamRulesUpdateError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: rules_data,
+            })
+        } else {
+            Err(StreamRulesUpdateError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
+impl DeleteStreamRules {
+    pub fn new(ids: Vec<String>) -> Self {
+        Self { ids }
+    }
+
+    fn url(&self) -> &'static str {
+        "https://api.x.com/2/tweets/search/stream/rules"
+    }
+
+    pub fn send(&self) -> Result<Response<StreamRulesUpdateResponse>, StreamRulesUpdateError> {
+        let url = self.url();
+        let authorization = bearer_auth_header();
+        let body = serde_json::to_string(&StreamRulesUpdatePayload {
+            add: None,
+            delete: Some(DeleteStreamRulesPayload {
+                ids: self.ids.as_slice(),
+            }),
+        })
+        .map_err(|err| StreamRulesUpdateError {
+            message: err.to_string(),
+        })?;
+
+        let response = curl_rest::Client::default()
+            .post()
+            .header(curl_rest::Header::Authorization(authorization.into()))
+            .body_json(body)
+            .send(url)
+            .map_err(|err| StreamRulesUpdateError {
+                message: err.to_string(),
+            })?;
+
+        if (200..300).contains(&response.status.as_u16()) {
+            let rules_data: StreamRulesUpdateResponse = serde_json::from_slice(&response.body)
+                .map_err(|err| StreamRulesUpdateError {
+                    message: err.to_string(),
+                })?;
+            Ok(Response {
+                status: response.status.as_u16(),
+                content: rules_data,
+            })
+        } else {
+            Err(StreamRulesUpdateError {
+                message: String::from_utf8_lossy(&response.body).to_string(),
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,6 +246,26 @@ mod tests {
     #[test]
     fn test_stream_rules_url_uses_rules_endpoint() {
         let endpoint = StreamRules;
+
+        assert_eq!(
+            endpoint.url(),
+            "https://api.x.com/2/tweets/search/stream/rules"
+        );
+    }
+
+    #[test]
+    fn test_add_stream_rule_url_uses_rules_endpoint() {
+        let endpoint = AddStreamRule::new("from:openai", Some("openai".to_string()));
+
+        assert_eq!(
+            endpoint.url(),
+            "https://api.x.com/2/tweets/search/stream/rules"
+        );
+    }
+
+    #[test]
+    fn test_delete_stream_rules_url_uses_rules_endpoint() {
+        let endpoint = DeleteStreamRules::new(vec!["1".to_string(), "2".to_string()]);
 
         assert_eq!(
             endpoint.url(),


### PR DESCRIPTION
## Summary
- add filtered stream rules update clients for POST /2/tweets/search/stream/rules
- wire new twitter streams rules add and delete commands into the CLI
- add URL coverage for the rules update endpoint

Fixes #48