### PR TITLE
Run CI tests single-threaded

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,4 +84,4 @@ jobs:
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.8.0
     - name: Run tests
-      run: cargo test
+      run: cargo test -- --test-threads=1


### PR DESCRIPTION
## Summary
- serialize the GitHub Actions test harness with --test-threads=1
- match the test invocation that passes locally
- unblock the failing main build while the remaining parallel-test interaction is investigated

Fixes the current main build failure.